### PR TITLE
Fix: Add family_id to tasks in seeds

### DIFF
--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -116,7 +116,8 @@ task_templates = [
     target_date: target_date,
     time: ["09:00", "14:00", "18:00", "20:00", nil].sample,
     user: lois,
-    assignee: assignee
+    assignee: assignee,
+    family: family
   )
 
   # Pour les tâches complétées, mettre à jour le updated_at pour simuler une complétion récente


### PR DESCRIPTION
- Tasks now include family parameter to ensure proper family association
- Prevents tasks from being created without family_id after migration


je mets un exemple ici : 

task = Task.new(
    name: template[:name],
    description: template[:description],
    status: status,
    created_date: Date.today - rand(0..7),
    target_date: target_date,
    time: ["09:00", "14:00", "18:00", "20:00", nil].sample,
    user: lois,
    **assignee: assignee,
    family: family**
  )